### PR TITLE
Use WP design components throughout the widget; refresh copy

### DIFF
--- a/assets/src/App.js
+++ b/assets/src/App.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from '@wordpress/element';
-import { Spinner, Notice } from '@wordpress/components';
+import { Spinner, Notice, Button } from '@wordpress/components';
 import { __, sprintf, _n } from '@wordpress/i18n';
+import { chevronDown, chevronRight } from '@wordpress/icons';
 import CaptureForm from './CaptureForm';
 import EntryRow from './EntryRow';
 import { listEntries, snoozeEntry, deleteEntry } from './api';
@@ -48,7 +49,6 @@ export default function App() {
 
 	const due = data?.due || [];
 	const pending = data?.pending || [];
-	const isEmpty = data && due.length === 0 && pending.length === 0;
 	const showPendingExpanded = pendingExpanded || pending.length <= 2;
 
 	return (
@@ -56,12 +56,6 @@ export default function App() {
 			{ SUBTITLE && <div className="future-drafts__subtitle">{ SUBTITLE }</div> }
 
 			<CaptureForm onCreated={ onCreated } />
-
-			{ isEmpty && (
-				<p className="future-drafts__empty-hint">
-					{ __( "Capture an experience now. We'll bring it back when you're ready to write about it.", 'future-drafts' ) }
-				</p>
-			) }
 
 			{ error && <Notice status="error" onRemove={ () => setError( null ) }>{ error }</Notice> }
 
@@ -84,9 +78,11 @@ export default function App() {
 
 			{ pending.length > 0 && (
 				<section className="future-drafts__section future-drafts__section--pending">
-					<button
-						type="button"
-						className="future-drafts__pending-toggle"
+					<Button
+						variant="tertiary"
+						size="small"
+						icon={ showPendingExpanded ? chevronDown : chevronRight }
+						iconPosition="left"
 						onClick={ () => setPendingExpanded( ( v ) => ! v ) }
 						aria-expanded={ showPendingExpanded }
 					>
@@ -95,8 +91,7 @@ export default function App() {
 							_n( '%d draft waiting', '%d drafts waiting', pending.length, 'future-drafts' ),
 							pending.length
 						) }
-						<span aria-hidden="true">{ showPendingExpanded ? ' ▾' : ' ▸' }</span>
-					</button>
+					</Button>
 					{ showPendingExpanded &&
 						pending.map( ( entry ) => (
 							<EntryRow

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -1,5 +1,6 @@
 import { useState } from '@wordpress/element';
 import {
+	BaseControl,
 	Button,
 	TextControl,
 	TextareaControl,
@@ -54,24 +55,25 @@ export default function CaptureForm( { onCreated } ) {
 	return (
 		<div className="future-drafts-capture">
 			<TextControl
-				label={ __( 'Title', 'future-drafts' ) }
+				label={ __( 'Title of Post', 'future-drafts' ) }
 				value={ title }
 				onChange={ setTitle }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<TextareaControl
-				label={ __( "What's coming up for you?", 'future-drafts' ) }
+				label={ __( 'Get a heads start', 'future-drafts' ) }
 				placeholder={ __( 'A few notes for your future self…', 'future-drafts' ) }
 				value={ content }
 				onChange={ setContent }
 				rows={ 3 }
 				__nextHasNoMarginBottom
 			/>
-			<div className="future-drafts-capture__date">
-				<div className="future-drafts-capture__date-label">
-					{ __( 'Remind me on', 'future-drafts' ) }
-				</div>
+			<BaseControl
+				__nextHasNoMarginBottom
+				label={ __( 'Remind me to pick this back up', 'future-drafts' ) }
+				id="future-drafts-capture-date"
+			>
 				<Flex gap={ 2 } justify="flex-start" wrap>
 					{ PRESETS.map( ( p ) => (
 						<FlexItem key={ p.key }>
@@ -113,7 +115,7 @@ export default function CaptureForm( { onCreated } ) {
 						/>
 					</FlexItem>
 				</Flex>
-			</div>
+			</BaseControl>
 			{ error && <Notice status="error" isDismissible={ false }>{ error }</Notice> }
 			<div className="future-drafts-capture__actions">
 				<Button

--- a/assets/src/EntryRow.js
+++ b/assets/src/EntryRow.js
@@ -1,6 +1,7 @@
 import { Button, ConfirmDialog } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { closeSmall, arrowRight } from '@wordpress/icons';
 import SnoozeMenu from './SnoozeMenu';
 import { today } from './api';
 
@@ -36,19 +37,24 @@ export default function EntryRow( { entry, variant, onSnooze, onDelete } ) {
 			</div>
 			<div className="future-drafts-row__actions">
 				{ isDue && (
-					<Button variant="primary" size="small" href={ entry.edit_url }>
-						{ __( 'Finish writing →', 'future-drafts' ) }
+					<Button
+						variant="primary"
+						size="small"
+						href={ entry.edit_url }
+						icon={ arrowRight }
+						iconPosition="right"
+					>
+						{ __( 'Finish writing', 'future-drafts' ) }
 					</Button>
 				) }
 				<SnoozeMenu onSnooze={ ( date ) => onSnooze( entry, date ) } />
 				<Button
 					variant="tertiary"
 					size="small"
+					icon={ closeSmall }
 					label={ __( 'Delete', 'future-drafts' ) }
 					onClick={ () => setConfirmingDelete( true ) }
-				>
-					×
-				</Button>
+				/>
 			</div>
 			{ confirmingDelete && (
 				<ConfirmDialog

--- a/assets/src/SnoozeMenu.js
+++ b/assets/src/SnoozeMenu.js
@@ -7,6 +7,7 @@ import {
 	DatePicker,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
 import { today, addDays, addMonths } from './api';
 
 const PRESETS = [
@@ -26,10 +27,12 @@ export default function SnoozeMenu( { onSnooze } ) {
 				<Button
 					variant="tertiary"
 					size="small"
+					icon={ chevronDown }
+					iconPosition="right"
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
 				>
-					{ __( 'Snooze ▾', 'future-drafts' ) }
+					{ __( 'Snooze', 'future-drafts' ) }
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) =>

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -6,12 +6,6 @@
 		margin: 0 0 12px;
 	}
 
-	&__empty-hint {
-		color: #50575e;
-		font-style: italic;
-		margin: 8px 0 0;
-	}
-
 	&__section {
 		margin-top: 16px;
 		padding-top: 12px;
@@ -34,39 +28,12 @@
 		letter-spacing: 0.04em;
 		color: #1d2327;
 	}
-
-	&__pending-toggle {
-		background: none;
-		border: 0;
-		padding: 4px 0;
-		font-size: 13px;
-		color: #2271b1;
-		cursor: pointer;
-
-		&:hover {
-			color: #135e96;
-		}
-	}
 }
 
 .future-drafts-capture {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-
-	&__date-label {
-		font-size: 11px;
-		font-weight: 500;
-		text-transform: uppercase;
-		color: #1d2327;
-		margin-bottom: 4px;
-	}
-
-	&__date {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
 
 	&__actions {
 		display: flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@babel/runtime": "^7.29.2",
         "@wordpress/env": "^10.0.0",
+        "@wordpress/icons": "^12.2.0",
         "@wordpress/scripts": "^28.0.0"
       }
     },
@@ -6183,6 +6184,13 @@
         "@types/pg": "*"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -6196,6 +6204,27 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
@@ -7163,6 +7192,36 @@
         "@types/node": "^20.17.10"
       }
     },
+    "node_modules/@wordpress/element": {
+      "version": "6.44.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.44.0.tgz",
+      "integrity": "sha512-kVCRSwGMPFu7oBcAzN0VzwFQw3mwctUb/TEHkGeG5An1Uus6olruGJyvFwkHNtO9WRCdTXXunUaSk0CIA9+Wig==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/escape-html": "^3.44.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/element/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@wordpress/env": {
       "version": "10.39.0",
       "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
@@ -7188,6 +7247,17 @@
       "bin": {
         "wp-env": "bin/wp-env"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/escape-html": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.44.0.tgz",
+      "integrity": "sha512-nAEshSe6IYFr3G8sfY8o9pYNTRKvxocQ3DXs3KUesmdaEtrtJSlDmrMOI3FIgaYfv1PP6d+cDZpsygp6IZGo2w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -7262,6 +7332,25 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@wordpress/icons": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.2.0.tgz",
+      "integrity": "sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.44.0",
+        "@wordpress/primitives": "^4.44.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/jest-console": {
@@ -7346,6 +7435,24 @@
       },
       "peerDependencies": {
         "prettier": ">=3"
+      }
+    },
+    "node_modules/@wordpress/primitives": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.44.0.tgz",
+      "integrity": "sha512-IqLL1EfhhyD9hp3G0q0Djp5HYbqXr7/f+FIj98SCovZnoo6YrVYwzFSrUvjFLr7RchyF19VzOEc0w0PpyhtxYA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.44.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/scripts": {
@@ -9631,6 +9738,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10439,6 +10556,13 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -19901,7 +20025,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -20751,7 +20874,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@babel/runtime": "^7.29.2",
     "@wordpress/env": "^10.0.0",
+    "@wordpress/icons": "^12.2.0",
     "@wordpress/scripts": "^28.0.0"
   }
 }

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -66,7 +66,7 @@ final class Widget
         wp_localize_script(self::HANDLE, 'futureDrafts', [
             'restNamespace' => Controller::NAMESPACE,
             'today'         => wp_date('Y-m-d'),
-            'subtitle'      => __('Drafts for your future self.', 'future-drafts'),
+            'subtitle'      => __("Drafts for your future self. We'll bring it back when you're ready to write about it.", 'future-drafts'),
         ]);
 
         wp_set_script_translations(self::HANDLE, 'future-drafts');


### PR DESCRIPTION
## Summary

A design pass on the dashboard widget — lean on WordPress's design system instead of ad-hoc markup, and tighten up the copy.

**Use WP components / icons instead of custom UI**
- ASCII glyphs (`▾`, `▸`, `×`, `→`) → `@wordpress/icons` (`chevronDown`, `chevronRight`, `closeSmall`, `arrowRight`)
- Raw `<button>` for the pending-drafts toggle → WP `Button`
- The custom uppercase "Remind me…" date label → `BaseControl`, so it matches the `TextControl`/`TextareaControl` labels above it
- Removed now-redundant CSS (`__pending-toggle`, `__date-label`, `__date`, `__empty-hint`)
- Added `@wordpress/icons` as a devDep; at runtime icons inline via `wp-primitives`, which WP admin already enqueues — visible in the regenerated `widget.asset.php`

**Copy updates**
- "Title" → "Title of Post"
- "What's coming up for you?" → "Get a heads start"
- "Remind me on" → "Remind me to pick this back up"
- Merged the bottom empty-state hint into the top subtitle so the framing lives in one place — subtitle now reads *"Drafts for your future self. We'll bring it back when you're ready to write about it."*

## Test plan

- [ ] `npm run build` succeeds
- [ ] Open the WP admin dashboard — the **Future Drafts** widget shows the new subtitle, the new label copy, and the icon-based buttons
- [ ] Capture a draft → it shows up under the pending toggle, which now uses a chevron icon
- [ ] Set a draft's date to today → it surfaces in "Ready to write" with an arrow-right "Finish writing" button
- [ ] Snooze and delete actions work; their buttons render with icons
- [ ] Visual sanity check on a non-default admin color scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)
