### PR TITLE
Fix "draft waiting" color to follow admin color scheme

### DIFF
--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -18,6 +18,20 @@
 			border-top: none;
 			margin-top: 12px;
 		}
+
+		// The pending toggle is a `<Button variant="tertiary">`. In the dashboard
+		// context the components stylesheet's `--wp-components-color-accent`
+		// mapping doesn't always pick up `--wp-admin-theme-color`, so the toggle
+		// renders in the default components blue regardless of admin scheme.
+		// Force the admin theme color so the link reads the active scheme.
+		&--pending .components-button.is-tertiary {
+			color: var( --wp-admin-theme-color, #2271b1 );
+
+			&:hover:not( :disabled ),
+			&:focus:not( :disabled ) {
+				color: var( --wp-admin-theme-color-darker-10, #135e96 );
+			}
+		}
 	}
 
 	&__heading {


### PR DESCRIPTION
Closes #2.

## Summary
- Adds a SCSS rule forcing `.future-drafts__section--pending .components-button.is-tertiary` to use `var(--wp-admin-theme-color)` (and `--wp-admin-theme-color-darker-10` on hover/focus).
- The pending-section toggle is a tertiary `Button` from `@wordpress/components`. In the dashboard, `--wp-components-color-accent` doesn't reliably resolve to `--wp-admin-theme-color`, so the toggle stays the default components blue across schemes.

## Why
Per #2, the "X draft waiting" text was rendering in a fixed blue regardless of the active admin color scheme. It should match the scheme — Modern, Sunrise, Ocean, etc.

## Test plan
- [ ] Run `npm run build`.
- [ ] Open WP admin with the **Fresh** scheme — toggle reads in the Fresh blue.
- [ ] Switch admin scheme to **Modern** (Users → Profile) — toggle adopts the Modern blue.
- [ ] Try **Sunrise** — toggle adopts the orange/red.
- [ ] Hover the toggle — color shifts to the darker-10 variant of the active scheme.