### PR TITLE
Restyle capture form labels and link-ify the date toggle

### DIFF
--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -1,8 +1,7 @@
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import {
 	Button,
 	DatePicker,
-	Dropdown,
 	Notice,
 	Flex,
 	FlexItem,
@@ -23,6 +22,30 @@ export default function CaptureForm( { onCreated } ) {
 	const [ date, setDate ] = useState( null );
 	const [ submitting, setSubmitting ] = useState( false );
 	const [ error, setError ] = useState( null );
+	const [ pickerOpen, setPickerOpen ] = useState( false );
+	const dateRowRef = useRef( null );
+
+	useEffect( () => {
+		if ( ! pickerOpen ) {
+			return;
+		}
+		const onDocMouseDown = ( e ) => {
+			if ( dateRowRef.current && ! dateRowRef.current.contains( e.target ) ) {
+				setPickerOpen( false );
+			}
+		};
+		const onKeyDown = ( e ) => {
+			if ( e.key === 'Escape' ) {
+				setPickerOpen( false );
+			}
+		};
+		document.addEventListener( 'mousedown', onDocMouseDown );
+		document.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			document.removeEventListener( 'mousedown', onDocMouseDown );
+			document.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [ pickerOpen ] );
 
 	const canSubmit = ( title.trim() !== '' || content.trim() !== '' ) && date && ! submitting;
 
@@ -84,58 +107,45 @@ export default function CaptureForm( { onCreated } ) {
 				<label htmlFor="future-drafts-date-toggle">
 					{ __( 'Remind me to pick this back up', 'future-drafts' ) }
 				</label>
-				<Flex gap={ 2 } justify="flex-start" wrap>
-					{ PRESETS.map( ( p ) => (
-						<FlexItem key={ p.key }>
+				<div className="future-drafts-capture__date-row" ref={ dateRowRef }>
+					<Flex gap={ 2 } justify="flex-start" wrap>
+						{ PRESETS.map( ( p ) => (
+							<FlexItem key={ p.key }>
+								<Button
+									variant={ date === p.apply( today() ) ? 'primary' : 'secondary' }
+									size="small"
+									onClick={ () => applyPreset( p ) }
+								>
+									{ p.label }
+								</Button>
+							</FlexItem>
+						) ) }
+						<FlexItem>
 							<Button
-								variant={ date === p.apply( today() ) ? 'primary' : 'secondary' }
-								size="small"
-								onClick={ () => applyPreset( p ) }
+								id="future-drafts-date-toggle"
+								variant="link"
+								className="future-drafts-capture__date-link"
+								onClick={ () => setPickerOpen( ( o ) => ! o ) }
+								aria-expanded={ pickerOpen }
 							>
-								{ p.label }
+								{ date
+									? dateI18n( 'M j, Y', `${ date }T00:00:00` )
+									: __( 'Pick a date', 'future-drafts' ) }
 							</Button>
 						</FlexItem>
-					) ) }
-					<FlexItem>
-						<Dropdown
-							popoverProps={ {
-								placement: 'right-start',
-								// Lock the top edge to the trigger so the
-								// calendar grows downward as months change
-								// height; without this Floating UI flips
-								// the placement when the popover would
-								// overflow the viewport, which moves the
-								// prev/next chevrons.
-								flip: false,
-								resize: false,
-							} }
-							renderToggle={ ( { isOpen, onToggle } ) => (
-								<Button
-									id="future-drafts-date-toggle"
-									variant="link"
-									className="future-drafts-capture__date-link"
-									onClick={ onToggle }
-									aria-expanded={ isOpen }
-								>
-									{ date
-										? dateI18n( 'M j, Y', `${ date }T00:00:00` )
-										: __( 'Pick a date', 'future-drafts' ) }
-								</Button>
-							) }
-							renderContent={ ( { onClose } ) => (
-								<div className="future-drafts-capture__datepicker">
-									<DatePicker
-										currentDate={ date || undefined }
-										onChange={ ( value ) => {
-											setDate( value ? value.slice( 0, 10 ) : null );
-											onClose();
-										} }
-									/>
-								</div>
-							) }
-						/>
-					</FlexItem>
-				</Flex>
+					</Flex>
+					{ pickerOpen && (
+						<div className="future-drafts-capture__datepicker">
+							<DatePicker
+								currentDate={ date || undefined }
+								onChange={ ( value ) => {
+									setDate( value ? value.slice( 0, 10 ) : null );
+									setPickerOpen( false );
+								} }
+							/>
+						</div>
+					) }
+				</div>
 			</div>
 
 			{ error && <Notice status="error" isDismissible={ false }>{ error }</Notice> }

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 import {
 	Button,
 	DatePicker,
@@ -23,27 +23,53 @@ export default function CaptureForm( { onCreated } ) {
 	const [ submitting, setSubmitting ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const [ pickerOpen, setPickerOpen ] = useState( false );
-	const dateRowRef = useRef( null );
+	const [ pickerPos, setPickerPos ] = useState( null );
+	const triggerRef = useRef( null );
+	const pickerRef = useRef( null );
+
+	const computePickerPos = useCallback( () => {
+		if ( ! triggerRef.current ) {
+			return null;
+		}
+		const rect = triggerRef.current.getBoundingClientRect();
+		return { top: rect.top, left: rect.right + 8 };
+	}, [] );
+
+	const openPicker = () => {
+		setPickerPos( computePickerPos() );
+		setPickerOpen( true );
+	};
 
 	useEffect( () => {
 		if ( ! pickerOpen ) {
 			return;
 		}
 		const onDocMouseDown = ( e ) => {
-			if ( dateRowRef.current && ! dateRowRef.current.contains( e.target ) ) {
-				setPickerOpen( false );
+			if ( triggerRef.current && triggerRef.current.contains( e.target ) ) {
+				return;
 			}
+			if ( pickerRef.current && pickerRef.current.contains( e.target ) ) {
+				return;
+			}
+			setPickerOpen( false );
 		};
 		const onKeyDown = ( e ) => {
 			if ( e.key === 'Escape' ) {
 				setPickerOpen( false );
 			}
 		};
+		const onScrollOrResize = () => {
+			setPickerOpen( false );
+		};
 		document.addEventListener( 'mousedown', onDocMouseDown );
 		document.addEventListener( 'keydown', onKeyDown );
+		window.addEventListener( 'scroll', onScrollOrResize, true );
+		window.addEventListener( 'resize', onScrollOrResize );
 		return () => {
 			document.removeEventListener( 'mousedown', onDocMouseDown );
 			document.removeEventListener( 'keydown', onKeyDown );
+			window.removeEventListener( 'scroll', onScrollOrResize, true );
+			window.removeEventListener( 'resize', onScrollOrResize );
 		};
 	}, [ pickerOpen ] );
 
@@ -107,46 +133,54 @@ export default function CaptureForm( { onCreated } ) {
 				<label htmlFor="future-drafts-date-toggle">
 					{ __( 'Remind me to pick this back up', 'future-drafts' ) }
 				</label>
-				<div className="future-drafts-capture__date-row" ref={ dateRowRef }>
-					<Flex gap={ 2 } justify="flex-start" wrap>
-						{ PRESETS.map( ( p ) => (
-							<FlexItem key={ p.key }>
-								<Button
-									variant={ date === p.apply( today() ) ? 'primary' : 'secondary' }
-									size="small"
-									onClick={ () => applyPreset( p ) }
-								>
-									{ p.label }
-								</Button>
-							</FlexItem>
-						) ) }
-						<FlexItem>
+				<Flex gap={ 2 } justify="flex-start" wrap>
+					{ PRESETS.map( ( p ) => (
+						<FlexItem key={ p.key }>
 							<Button
-								id="future-drafts-date-toggle"
-								variant="link"
-								className="future-drafts-capture__date-link"
-								onClick={ () => setPickerOpen( ( o ) => ! o ) }
-								aria-expanded={ pickerOpen }
+								variant={ date === p.apply( today() ) ? 'primary' : 'secondary' }
+								size="small"
+								onClick={ () => applyPreset( p ) }
 							>
-								{ date
-									? dateI18n( 'M j, Y', `${ date }T00:00:00` )
-									: __( 'Pick a date', 'future-drafts' ) }
+								{ p.label }
 							</Button>
 						</FlexItem>
-					</Flex>
-					{ pickerOpen && (
-						<div className="future-drafts-capture__datepicker">
-							<DatePicker
-								currentDate={ date || undefined }
-								onChange={ ( value ) => {
-									setDate( value ? value.slice( 0, 10 ) : null );
-									setPickerOpen( false );
-								} }
-							/>
-						</div>
-					) }
-				</div>
+					) ) }
+					<FlexItem>
+						<Button
+							ref={ triggerRef }
+							id="future-drafts-date-toggle"
+							variant="link"
+							className="future-drafts-capture__date-link"
+							onClick={ () => ( pickerOpen ? setPickerOpen( false ) : openPicker() ) }
+							aria-expanded={ pickerOpen }
+						>
+							{ date
+								? dateI18n( 'M j, Y', `${ date }T00:00:00` )
+								: __( 'Pick a date', 'future-drafts' ) }
+						</Button>
+					</FlexItem>
+				</Flex>
 			</div>
+
+			{ pickerOpen && pickerPos && (
+				<div
+					ref={ pickerRef }
+					className="future-drafts-capture__datepicker"
+					style={ {
+						position: 'fixed',
+						top: pickerPos.top,
+						left: pickerPos.left,
+					} }
+				>
+					<DatePicker
+						currentDate={ date || undefined }
+						onChange={ ( value ) => {
+							setDate( value ? value.slice( 0, 10 ) : null );
+							setPickerOpen( false );
+						} }
+					/>
+				</div>
+			) }
 
 			{ error && <Notice status="error" isDismissible={ false }>{ error }</Notice> }
 			<div className="future-drafts-capture__actions">

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -32,7 +32,7 @@ export default function CaptureForm( { onCreated } ) {
 			return null;
 		}
 		const rect = triggerRef.current.getBoundingClientRect();
-		return { top: rect.top - 175, left: rect.right + 8 };
+		return { top: rect.top - 150, left: rect.right + 8 };
 	}, [] );
 
 	const openPicker = () => {

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -55,14 +55,14 @@ export default function CaptureForm( { onCreated } ) {
 	return (
 		<div className="future-drafts-capture">
 			<TextControl
-				label={ __( 'Title', 'future-drafts' ) }
+				label={ __( 'Title of Post', 'future-drafts' ) }
 				value={ title }
 				onChange={ setTitle }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<TextareaControl
-				label={ __( 'Content', 'future-drafts' ) }
+				label={ __( 'Get a heads start', 'future-drafts' ) }
 				placeholder={ __( 'A few notes for your future self…', 'future-drafts' ) }
 				value={ content }
 				onChange={ setContent }

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -1,9 +1,6 @@
 import { useState } from '@wordpress/element';
 import {
-	BaseControl,
 	Button,
-	TextControl,
-	TextareaControl,
 	DatePicker,
 	Dropdown,
 	Notice,
@@ -54,26 +51,39 @@ export default function CaptureForm( { onCreated } ) {
 
 	return (
 		<div className="future-drafts-capture">
-			<TextControl
-				label={ __( 'Title of Post', 'future-drafts' ) }
-				value={ title }
-				onChange={ setTitle }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-			/>
-			<TextareaControl
-				label={ __( 'Get a heads start', 'future-drafts' ) }
-				placeholder={ __( 'A few notes for your future self…', 'future-drafts' ) }
-				value={ content }
-				onChange={ setContent }
-				rows={ 3 }
-				__nextHasNoMarginBottom
-			/>
-			<BaseControl
-				__nextHasNoMarginBottom
-				label={ __( 'Remind me to pick this back up', 'future-drafts' ) }
-				id="future-drafts-capture-date"
-			>
+			<div className="input-text-wrap">
+				<label htmlFor="future-drafts-title">
+					{ __( 'Title of Post', 'future-drafts' ) }
+				</label>
+				<input
+					type="text"
+					id="future-drafts-title"
+					name="future-drafts-title"
+					value={ title }
+					onChange={ ( e ) => setTitle( e.target.value ) }
+					autoComplete="off"
+				/>
+			</div>
+
+			<div className="textarea-wrap">
+				<label htmlFor="future-drafts-content">
+					{ __( 'Get a heads start', 'future-drafts' ) }
+				</label>
+				<textarea
+					id="future-drafts-content"
+					name="future-drafts-content"
+					placeholder={ __( 'A few notes for your future self…', 'future-drafts' ) }
+					rows={ 3 }
+					value={ content }
+					onChange={ ( e ) => setContent( e.target.value ) }
+					autoComplete="off"
+				/>
+			</div>
+
+			<div className="future-drafts-capture__date">
+				<label htmlFor="future-drafts-date-toggle">
+					{ __( 'Remind me to pick this back up', 'future-drafts' ) }
+				</label>
 				<Flex gap={ 2 } justify="flex-start" wrap>
 					{ PRESETS.map( ( p ) => (
 						<FlexItem key={ p.key }>
@@ -91,6 +101,7 @@ export default function CaptureForm( { onCreated } ) {
 							popoverProps={ { placement: 'bottom-start' } }
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button
+									id="future-drafts-date-toggle"
 									variant="link"
 									className="future-drafts-capture__date-link"
 									onClick={ onToggle }
@@ -115,7 +126,8 @@ export default function CaptureForm( { onCreated } ) {
 						/>
 					</FlexItem>
 				</Flex>
-			</BaseControl>
+			</div>
+
 			{ error && <Notice status="error" isDismissible={ false }>{ error }</Notice> }
 			<div className="future-drafts-capture__actions">
 				<Button

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -55,14 +55,14 @@ export default function CaptureForm( { onCreated } ) {
 	return (
 		<div className="future-drafts-capture">
 			<TextControl
-				label={ __( 'Title of Post', 'future-drafts' ) }
+				label={ __( 'Title', 'future-drafts' ) }
 				value={ title }
 				onChange={ setTitle }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<TextareaControl
-				label={ __( 'Get a heads start', 'future-drafts' ) }
+				label={ __( 'Content', 'future-drafts' ) }
 				placeholder={ __( 'A few notes for your future self…', 'future-drafts' ) }
 				value={ content }
 				onChange={ setContent }
@@ -91,8 +91,8 @@ export default function CaptureForm( { onCreated } ) {
 							popoverProps={ { placement: 'bottom-start' } }
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button
-									variant="secondary"
-									size="small"
+									variant="link"
+									className="future-drafts-capture__date-link"
 									onClick={ onToggle }
 									aria-expanded={ isOpen }
 								>

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -32,7 +32,7 @@ export default function CaptureForm( { onCreated } ) {
 			return null;
 		}
 		const rect = triggerRef.current.getBoundingClientRect();
-		return { top: rect.top, left: rect.right + 8 };
+		return { top: rect.top - 175, left: rect.right + 8 };
 	}, [] );
 
 	const openPicker = () => {

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -98,7 +98,17 @@ export default function CaptureForm( { onCreated } ) {
 					) ) }
 					<FlexItem>
 						<Dropdown
-							popoverProps={ { placement: 'right-start' } }
+							popoverProps={ {
+								placement: 'right-start',
+								// Lock the top edge to the trigger so the
+								// calendar grows downward as months change
+								// height; without this Floating UI flips
+								// the placement when the popover would
+								// overflow the viewport, which moves the
+								// prev/next chevrons.
+								flip: false,
+								resize: false,
+							} }
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button
 									id="future-drafts-date-toggle"

--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -98,7 +98,7 @@ export default function CaptureForm( { onCreated } ) {
 					) ) }
 					<FlexItem>
 						<Dropdown
-							popoverProps={ { placement: 'bottom-start' } }
+							popoverProps={ { placement: 'right-start' } }
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button
 									id="future-drafts-date-toggle"

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -135,7 +135,28 @@
 	}
 }
 
-.future-drafts-snooze__custom,
-.future-drafts-capture__datepicker {
+.future-drafts-snooze__custom {
 	padding: 8px;
+}
+
+.future-drafts-capture__date-row {
+	position: relative;
+}
+
+// Inline date picker, manually positioned to the right of the trigger
+// row so its top edge stays put as the calendar height changes
+// month-to-month. We render it ourselves instead of using <Dropdown>
+// so Floating UI can't reflow placement when the height grows.
+.future-drafts-capture__datepicker {
+	position: absolute;
+	top: 0;
+	left: 100%;
+	margin-left: 8px;
+	z-index: 100000;
+	min-width: 280px;
+	padding: 12px;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	box-shadow: 0 4px 12px rgba( 0, 0, 0, 0.08 );
 }

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -139,19 +139,12 @@
 	padding: 8px;
 }
 
-.future-drafts-capture__date-row {
-	position: relative;
-}
-
-// Inline date picker, manually positioned to the right of the trigger
-// row so its top edge stays put as the calendar height changes
-// month-to-month. We render it ourselves instead of using <Dropdown>
-// so Floating UI can't reflow placement when the height grows.
+// Inline date picker positioned via JS (position: fixed, top/left set
+// from the trigger's getBoundingClientRect) so it sits flush next to
+// the Pick a date link and escapes the dashboard widget's overflow
+// clipping. Top stays put as the calendar height changes; closes on
+// scroll/resize since it can't follow.
 .future-drafts-capture__datepicker {
-	position: absolute;
-	top: 0;
-	left: 100%;
-	margin-left: 8px;
 	z-index: 100000;
 	min-width: 280px;
 	padding: 12px;

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -54,6 +54,22 @@
 		justify-content: flex-end;
 		margin-top: 4px;
 	}
+
+	// Link-styled toggle that sits next to the preset buttons. Matches the
+	// secondary-action treatment Draft Sweeper uses for its "Not today" link
+	// (.ds-dismiss): no chrome, admin-scheme accent, underline on hover only.
+	&__date-link.components-button.is-link {
+		color: var( --wp-admin-theme-color, #2271b1 );
+		text-decoration: none;
+		box-shadow: none;
+
+		&:hover:not( :disabled ),
+		&:focus:not( :disabled ),
+		&:focus-visible:not( :disabled ) {
+			color: var( --wp-admin-theme-color, #2271b1 );
+			text-decoration: underline;
+		}
+	}
 }
 
 .future-drafts-row {

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -55,6 +55,20 @@
 		margin-top: 4px;
 	}
 
+	// Match the plain <label> look that core's Quick Draft widget uses on
+	// the dashboard, instead of the @wordpress/components default
+	// (11px / 500 / uppercase emotion typography). Doubled class to win
+	// specificity against the emotion-generated rule.
+	.components-base-control__label.components-base-control__label {
+		font-size: 13px;
+		font-weight: 400;
+		line-height: 1.4;
+		letter-spacing: 0;
+		text-transform: none;
+		color: #1d2327;
+		margin-bottom: 4px;
+	}
+
 	// Link-styled toggle that sits next to the preset buttons. Matches the
 	// secondary-action treatment Draft Sweeper uses for its "Not today" link
 	// (.ds-dismiss): no chrome, admin-scheme accent, underline on hover only.

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -55,18 +55,16 @@
 		margin-top: 4px;
 	}
 
-	// Match the plain <label> look that core's Quick Draft widget uses on
-	// the dashboard, instead of the @wordpress/components default
-	// (11px / 500 / uppercase emotion typography). Doubled class to win
-	// specificity against the emotion-generated rule.
-	.components-base-control__label.components-base-control__label {
-		font-size: 13px;
-		font-weight: 400;
-		line-height: 1.4;
-		letter-spacing: 0;
-		text-transform: none;
-		color: #1d2327;
+	label {
+		display: inline-block;
 		margin-bottom: 4px;
+	}
+
+	input[type="text"],
+	textarea {
+		width: 100%;
+		box-sizing: border-box;
+		margin: 0;
 	}
 
 	// Link-styled toggle that sits next to the preset buttons. Matches the

--- a/future-drafts.php
+++ b/future-drafts.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Future Drafts
  * Description: Drafts for your future self. Capture an experience now; finish writing about it later.
- * Version:     0.1.0
+ * Version:     0.2.0
  * Author:      Anne McCarthy
  * License:     GPL-2.0-or-later
  * Text Domain: future-drafts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-drafts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "WordPress dashboard widget for time-delayed drafts.",
   "private": true,
   "scripts": {

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -46,7 +46,7 @@ final class Widget
         $build = plugin_dir_path($this->pluginFile) . 'build/widget.asset.php';
         $asset = file_exists($build)
             ? require $build
-            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.1.0'];
+            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.2.0'];
 
         wp_enqueue_script(
             self::HANDLE,

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -66,7 +66,7 @@ final class Widget
         wp_localize_script(self::HANDLE, 'futureDrafts', [
             'restNamespace' => Controller::NAMESPACE,
             'today'         => wp_date('Y-m-d'),
-            'subtitle'      => __("Drafts for your future self. We'll bring it back when you're ready to write about it.", 'future-drafts'),
+            'subtitle'      => __("Create a draft for your future self. We'll bring it back when you're ready to finish writing.", 'future-drafts'),
         ]);
 
         wp_set_script_translations(self::HANDLE, 'future-drafts');


### PR DESCRIPTION
## Summary
- Capture form ditches `TextControl` / `TextareaControl` / `BaseControl` and uses plain `<label>` + `<input type="text">` / `<textarea>` inside `.input-text-wrap` / `.textarea-wrap` — same markup pattern core uses for Quick Draft (`wp-admin/includes/dashboard.php`, `wp_dashboard_quick_press`). Plain HTML form elements inherit WP admin's default form styling, so the labels and inputs visually match Quick Draft for free.
- The "Pick a date" toggle becomes a link-styled control. Same idiom as Draft Sweeper's `.ds-dismiss` — `--wp-admin-theme-color` accent, no chrome, underline on hover only — so it reads as a secondary action next to the 1 week / 1 month / 3 months presets without competing visually.
- Bumps plugin version to 0.2.0 for cache busting.

## Test plan
- [ ] Load the dashboard at `/wp-admin/` and confirm the Future Drafts capture form labels and inputs look the same as Quick Draft's sitting on the same screen.
- [ ] Confirm the "Pick a date" control renders inline with the preset buttons as a text link (admin-scheme color, no border/background).
- [ ] Hover the date control — it should underline; no underline at rest.
- [ ] Open the date picker, pick a date — the link text replaces "Pick a date" with the formatted date.
- [ ] Switch admin color scheme (Users → Profile) and confirm the link follows the active accent color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
