### PR TITLE
Redesign the due-drafts section

### DIFF
--- a/assets/src/App.js
+++ b/assets/src/App.js
@@ -55,12 +55,6 @@ export default function App() {
 		<div className="future-drafts">
 			{ SUBTITLE && <div className="future-drafts__subtitle">{ SUBTITLE }</div> }
 
-			<CaptureForm onCreated={ onCreated } />
-
-			{ error && <Notice status="error" onRemove={ () => setError( null ) }>{ error }</Notice> }
-
-			{ data === null && <Spinner /> }
-
 			{ due.length > 0 && (
 				<section className="future-drafts__section future-drafts__section--due">
 					<h3 className="future-drafts__heading">{ __( 'Ready to write', 'future-drafts' ) }</h3>
@@ -75,6 +69,12 @@ export default function App() {
 					) ) }
 				</section>
 			) }
+
+			<CaptureForm onCreated={ onCreated } />
+
+			{ error && <Notice status="error" onRemove={ () => setError( null ) }>{ error }</Notice> }
+
+			{ data === null && <Spinner /> }
 
 			{ pending.length > 0 && (
 				<section className="future-drafts__section future-drafts__section--pending">

--- a/assets/src/App.js
+++ b/assets/src/App.js
@@ -57,7 +57,14 @@ export default function App() {
 
 			{ due.length > 0 && (
 				<section className="future-drafts__section future-drafts__section--due">
-					<h3 className="future-drafts__heading">{ __( 'Pick this draft back up', 'future-drafts' ) }</h3>
+					<h3 className="future-drafts__heading">
+						{ _n(
+							'Pick this draft back up',
+							'Pick these drafts back up',
+							due.length,
+							'future-drafts'
+						) }
+					</h3>
 					{ due.map( ( entry ) => (
 						<EntryRow
 							key={ entry.id }

--- a/assets/src/App.js
+++ b/assets/src/App.js
@@ -57,7 +57,7 @@ export default function App() {
 
 			{ due.length > 0 && (
 				<section className="future-drafts__section future-drafts__section--due">
-					<h3 className="future-drafts__heading">{ __( 'Ready to write', 'future-drafts' ) }</h3>
+					<h3 className="future-drafts__heading">{ __( 'Pick this draft back up', 'future-drafts' ) }</h3>
 					{ due.map( ( entry ) => (
 						<EntryRow
 							key={ entry.id }

--- a/assets/src/EntryRow.js
+++ b/assets/src/EntryRow.js
@@ -48,6 +48,7 @@ export default function EntryRow( { entry, variant, onSnooze, onDelete } ) {
 					variant="tertiary"
 					size="small"
 					icon={ trash }
+					className="future-drafts-row__delete"
 					label={ __( 'Delete', 'future-drafts' ) }
 					onClick={ () => setConfirmingDelete( true ) }
 				/>

--- a/assets/src/EntryRow.js
+++ b/assets/src/EntryRow.js
@@ -1,7 +1,7 @@
 import { Button, ConfirmDialog } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { closeSmall, arrowRight } from '@wordpress/icons';
+import { closeSmall } from '@wordpress/icons';
 import SnoozeMenu from './SnoozeMenu';
 import { today } from './api';
 
@@ -37,13 +37,7 @@ export default function EntryRow( { entry, variant, onSnooze, onDelete } ) {
 			</div>
 			<div className="future-drafts-row__actions">
 				{ isDue && (
-					<Button
-						variant="primary"
-						size="small"
-						href={ entry.edit_url }
-						icon={ arrowRight }
-						iconPosition="right"
-					>
+					<Button variant="primary" href={ entry.edit_url }>
 						{ __( 'Finish writing', 'future-drafts' ) }
 					</Button>
 				) }

--- a/assets/src/EntryRow.js
+++ b/assets/src/EntryRow.js
@@ -33,7 +33,9 @@ export default function EntryRow( { entry, variant, onSnooze, onDelete } ) {
 				{ entry.excerpt && (
 					<div className="future-drafts-row__excerpt">{ entry.excerpt }</div>
 				) }
-				<div className="future-drafts-row__meta">{ relativeLabel( entry.remind_on ) }</div>
+				{ ! isDue && (
+					<div className="future-drafts-row__meta">{ relativeLabel( entry.remind_on ) }</div>
+				) }
 			</div>
 			<div className="future-drafts-row__actions">
 				{ isDue && (

--- a/assets/src/EntryRow.js
+++ b/assets/src/EntryRow.js
@@ -1,7 +1,7 @@
 import { Button, ConfirmDialog } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { closeSmall } from '@wordpress/icons';
+import { trash } from '@wordpress/icons';
 import SnoozeMenu from './SnoozeMenu';
 import { today } from './api';
 
@@ -38,16 +38,16 @@ export default function EntryRow( { entry, variant, onSnooze, onDelete } ) {
 				) }
 			</div>
 			<div className="future-drafts-row__actions">
+				<SnoozeMenu onSnooze={ ( date ) => onSnooze( entry, date ) } />
 				{ isDue && (
 					<Button variant="primary" href={ entry.edit_url }>
 						{ __( 'Finish writing', 'future-drafts' ) }
 					</Button>
 				) }
-				<SnoozeMenu onSnooze={ ( date ) => onSnooze( entry, date ) } />
 				<Button
 					variant="tertiary"
 					size="small"
-					icon={ closeSmall }
+					icon={ trash }
 					label={ __( 'Delete', 'future-drafts' ) }
 					onClick={ () => setConfirmingDelete( true ) }
 				/>

--- a/assets/src/SnoozeMenu.js
+++ b/assets/src/SnoozeMenu.js
@@ -26,7 +26,6 @@ export default function SnoozeMenu( { onSnooze } ) {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					variant="tertiary"
-					size="small"
 					icon={ chevronDown }
 					iconPosition="right"
 					onClick={ onToggle }

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -17,7 +17,7 @@
 			border-radius: 4px;
 			border-top: none;
 			margin-top: 12px;
-			margin-bottom: 20px;
+			margin-bottom: 14px;
 		}
 
 		// The pending toggle is a `<Button variant="tertiary">`. In the dashboard

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -125,7 +125,7 @@
 		flex-shrink: 0;
 		flex-wrap: wrap;
 		justify-content: flex-end;
-		align-items: baseline;
+		align-items: center;
 	}
 }
 

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -17,6 +17,7 @@
 			border-radius: 4px;
 			border-top: none;
 			margin-top: 12px;
+			margin-bottom: 20px;
 		}
 
 		// The pending toggle is a `<Button variant="tertiary">`. In the dashboard

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -127,6 +127,10 @@
 		justify-content: flex-end;
 		align-items: center;
 	}
+
+	&__delete {
+		margin-left: 4px;
+	}
 }
 
 .future-drafts-snooze__custom {

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -35,14 +35,6 @@
 		}
 	}
 
-	&__heading {
-		font-size: 13px;
-		font-weight: 600;
-		margin: 0 0 8px;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		color: #1d2327;
-	}
 }
 
 .future-drafts-capture {

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -125,6 +125,7 @@
 		flex-shrink: 0;
 		flex-wrap: wrap;
 		justify-content: flex-end;
+		align-items: baseline;
 	}
 }
 

--- a/future-drafts.php
+++ b/future-drafts.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Future Drafts
  * Description: Drafts for your future self. Capture an experience now; finish writing about it later.
- * Version:     0.2.0
+ * Version:     0.2.1
  * Author:      Anne McCarthy
  * License:     GPL-2.0-or-later
  * Text Domain: future-drafts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-drafts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "WordPress dashboard widget for time-delayed drafts.",
   "private": true,
   "scripts": {

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -46,7 +46,7 @@ final class Widget
         $build = plugin_dir_path($this->pluginFile) . 'build/widget.asset.php';
         $asset = file_exists($build)
             ? require $build
-            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.2.0'];
+            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.2.1'];
 
         wp_enqueue_script(
             self::HANDLE,


### PR DESCRIPTION
## Summary
Reworks the "due drafts" section of the Future Drafts widget end to end.

**Placement & spacing**
- Section moves above the capture form so due drafts are the first thing visible.
- 14px bottom margin added so it doesn't crowd the capture form below.

**Heading**
- Renamed from "Ready to write" to "Pick this draft back up" (singular) / "Pick these drafts back up" (plural via `_n`).
- Dropped the custom uppercase + letter-spacing styles; the `<h3>` now inherits core's `#dashboard-widgets h3` rule so it visually matches Quick Draft's "Your Recent Drafts".

**Rows**
- Removed the "today" meta line on due rows (redundant — the section heading already implies it).
- Action button order is now [Snooze] [Finish writing] [Delete].
- "Snooze" is default-size (matches "Finish writing") and sits on the same baseline.
- "Finish writing" is default-size and no longer carries an arrow icon.
- Delete is now a trash icon instead of an X, with a small left margin separating it from the primary actions.
- All three actions are vertically centered.

Bumps plugin version 0.2.0 → 0.2.1.

## Test plan
- [ ] With one due draft: heading reads **Pick this draft back up**. With two+: **Pick these drafts back up**.
- [ ] Section sits above the capture form with comfortable breathing room below it.
- [ ] No "today" line on due rows; pending rows still show their relative date.
- [ ] Row actions read left-to-right as Snooze, Finish writing, trash icon — visually centered, text baselines aligned for the two text buttons.
- [ ] Heading visually matches Quick Draft's "Your Recent Drafts" header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
