### PR TITLE
Hide subtitle once there are drafts in the widget

### DIFF
--- a/assets/src/App.js
+++ b/assets/src/App.js
@@ -50,10 +50,13 @@ export default function App() {
 	const due = data?.due || [];
 	const pending = data?.pending || [];
 	const showPendingExpanded = pendingExpanded || pending.length <= 2;
+	const isEmpty = data !== null && due.length === 0 && pending.length === 0;
 
 	return (
 		<div className="future-drafts">
-			{ SUBTITLE && <div className="future-drafts__subtitle">{ SUBTITLE }</div> }
+			{ SUBTITLE && isEmpty && (
+				<div className="future-drafts__subtitle">{ SUBTITLE }</div>
+			) }
 
 			{ due.length > 0 && (
 				<section className="future-drafts__section future-drafts__section--due">

--- a/future-drafts.php
+++ b/future-drafts.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Future Drafts
  * Description: Drafts for your future self. Capture an experience now; finish writing about it later.
- * Version:     0.2.1
+ * Version:     0.2.2
  * Author:      Anne McCarthy
  * License:     GPL-2.0-or-later
  * Text Domain: future-drafts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-drafts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "WordPress dashboard widget for time-delayed drafts.",
   "private": true,
   "scripts": {

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -46,7 +46,7 @@ final class Widget
         $build = plugin_dir_path($this->pluginFile) . 'build/widget.asset.php';
         $asset = file_exists($build)
             ? require $build
-            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.2.1'];
+            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.2.2'];
 
         wp_enqueue_script(
             self::HANDLE,


### PR DESCRIPTION
## Summary
- Hides the intro subtitle ("Create a draft for your future self. We'll bring it back when you're ready to finish writing.") once at least one draft exists in the widget. Empty state still shows it as the welcome / onboarding copy.
- Bumps plugin version to 0.2.2.

Stacks on [#5](https://github.com/annezazu/future-drafts/pull/5) — needs that to land first.

## Test plan
- [ ] Empty state (no due, no pending drafts): subtitle visible above the capture form.
- [ ] After creating a draft: subtitle is gone.
- [ ] Delete the last remaining draft: subtitle comes back without a reload.
- [ ] During initial load (before the entries fetch resolves): subtitle is hidden — Spinner takes its place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
