### PR TITLE
Future Drafts design details

### DIFF
--- a/assets/src/CaptureForm.js
+++ b/assets/src/CaptureForm.js
@@ -159,6 +159,16 @@ export default function CaptureForm( { onCreated } ) {
 								: __( 'Pick a date', 'future-drafts' ) }
 						</Button>
 					</FlexItem>
+					<FlexItem className="future-drafts-capture__save">
+						<Button
+							variant="primary"
+							onClick={ submit }
+							disabled={ ! canSubmit }
+							isBusy={ submitting }
+						>
+							{ __( 'Save for later', 'future-drafts' ) }
+						</Button>
+					</FlexItem>
 				</Flex>
 			</div>
 
@@ -183,16 +193,6 @@ export default function CaptureForm( { onCreated } ) {
 			) }
 
 			{ error && <Notice status="error" isDismissible={ false }>{ error }</Notice> }
-			<div className="future-drafts-capture__actions">
-				<Button
-					variant="primary"
-					onClick={ submit }
-					disabled={ ! canSubmit }
-					isBusy={ submitting }
-				>
-					{ __( 'Save for later', 'future-drafts' ) }
-				</Button>
-			</div>
 		</div>
 	);
 }

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -37,7 +37,7 @@
 		&--due {
 			background: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 6%, transparent );
 			padding: 12px;
-			border: 1px solid var( --wpds-color-stroke-surface-neutral-weak, #dcdcde );
+			border: 1px solid color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 30%, #fff );
 			border-radius: 4px;
 			margin-top: 12px;
 			margin-bottom: 14px;

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -19,6 +19,11 @@
 #future_drafts_widget .inside:has( .future-drafts__section--pending ) .future-drafts__main {
 	background: #fff;
 	padding: 0 12px 16px;
+	// Contain the first child's margin-top so it doesn't collapse up
+	// through __main and reveal .inside's gray background above the
+	// white card. display: flow-root creates a block formatting
+	// context, same idea as overflow: hidden but without clipping.
+	display: flow-root;
 }
 
 .future-drafts {

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -37,8 +37,8 @@
 		&--due {
 			background: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 6%, transparent );
 			padding: 12px;
+			border: 1px solid var( --wpds-color-stroke-surface-neutral-weak, #dcdcde );
 			border-radius: 4px;
-			border-top: none;
 			margin-top: 12px;
 			margin-bottom: 14px;
 		}

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -108,10 +108,8 @@
 	flex-direction: column;
 	gap: 8px;
 
-	&__actions {
-		display: flex;
-		justify-content: flex-end;
-		margin-top: 4px;
+	&__save {
+		margin-left: auto;
 	}
 
 	label {

--- a/assets/src/widget.scss
+++ b/assets/src/widget.scss
@@ -44,7 +44,7 @@
 			padding: 12px;
 			border: 1px solid color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 30%, #fff );
 			border-radius: 4px;
-			margin-top: 12px;
+			margin-top: 4px;
 			margin-bottom: 14px;
 		}
 

--- a/future-drafts.php
+++ b/future-drafts.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Future Drafts
  * Description: Drafts for your future self. Capture an experience now; finish writing about it later.
- * Version:     0.2.4
+ * Version:     0.2.5
  * Author:      Anne McCarthy
  * License:     GPL-2.0-or-later
  * Text Domain: future-drafts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "future-drafts",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "WordPress dashboard widget for time-delayed drafts.",
   "private": true,
   "scripts": {

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -46,7 +46,7 @@ final class Widget
         $build = plugin_dir_path($this->pluginFile) . 'build/widget.asset.php';
         $asset = file_exists($build)
             ? require $build
-            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.2.4'];
+            : ['dependencies' => ['wp-element', 'wp-components', 'wp-api-fetch', 'wp-i18n'], 'version' => '0.2.5'];
 
         wp_enqueue_script(
             self::HANDLE,


### PR DESCRIPTION
## Summary
Small design pass on the Future Drafts widget. First change:

- `.future-drafts__section--due` now has a 1px `#dcdcde` border (same WPDS stroke token used by the pending band), so the card reads as a contained, framed unit instead of a bare tinted block. Dropped the no-longer-needed `border-top: none` override.

Bumps plugin version 0.2.4 → 0.2.5.

More tweaks likely to land on this branch as we go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
